### PR TITLE
Move documentation to twilio.com/docs/authy/api

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,319 +1,76 @@
-# Authy
-
-Java library to access the Authy API
-
 [![Build Status](https://travis-ci.org/twilio/authy-java.svg?branch=master)](https://travis-ci.org/twilio/authy-java)
 [![codecov.io](http://codecov.io/github/twilio/authy-java/coverage.svg?branch=master)](https://codecov.io/gh/twilio/authy-java)
 
-## Dependencies
+# Java Client for Twilio Authy Two-Factor Authentication (2FA) API
 
-### JSON Library
-This project use [json.org](https://github.com/douglascrockford/JSON-java) you can find
+Documentation for Java usage of the Authy API lives in the [official Twilio documentation](https://www.twilio.com/docs/authy/api/).
+
+The Authy API supports multiple channels of 2FA:
+* One-time passwords via SMS and voice.
+* Soft token ([TOTP](https://www.twilio.com/docs/glossary/totp) via the Authy App)
+* Push authentication via the Authy App
+
+If you only need SMS and Voice support for one-time passwords, we recommend using the [Twilio Verify API](https://www.twilio.com/docs/verify/api) instead. 
+
+[More on how to choose between Authy and Verify here.](https://www.twilio.com/docs/verify/authy-vs-verify)
+
+### Authy Quickstart
+
+For a full tutorial, check out either of the Java Authy Quickstarts in our docs:
+* [Java/Spring Authy Quickstart](https://www.twilio.com/docs/authy/quickstart/two-factor-authentication-java-spring)
+* [Java/Servlets Authy Quickstart](https://www.twilio.com/docs/authy/quickstart/two-factor-authentication-java-servlets)
+
+## Authy Java Installation
+
+### Dependencies
+This project uses [json.org](https://github.com/douglascrockford/JSON-java), you can find
 the [json.org jar versions here](https://search.maven.org/#search|gav|1|g%3A%22org.json%22%20AND%20a%3A%22json%22)
 
-* Using Ant you don't need to include json.org since ant is including it in the final jar.
-
-* Using Maven you need to include the [json.org jar](https://search.maven.org/#search|gav|1|g%3A%22org.json%22%20AND%20a%3A%22json%22) in your jar external libraries.
-
-## Compilation
-
-### Using Apache Maven
-
-Use `mvn install` to compile and install the library in your local maven repository. This also installs the sources JAR file for source code lookup for better debugging.
-
-You will also find the JAR files in the `target` directory.
-
-Also you can use Use `mvn test` if you want to run tests.
+* **Ant:** no need to include json.org since ant already includes it in the final jar.
+* **Maven:** need to include the [json.org jar](https://search.maven.org/#search|gav|1|g%3A%22org.json%22%20AND%20a%3A%22json%22) in your jar external libraries.
 
 ## Usage
 
-Import API:
+Add the library to the project by putting it in the dependencies section of your `pom.xml`:
+```
+<!-- https://mvnrepository.com/artifact/com.authy/authy-java -->
+<dependency>
+    <groupId>com.authy</groupId>
+    <artifactId>authy-java</artifactId>
+    <version>1.5.0</version>
+</dependency>
+```
+
+To use the Authy client, import the API and initialize it with your production API Key found in the [Twilio Console](https://www.twilio.com/console/authy/applications/):
+
 ```java
 import com.authy.*;
 import com.authy.api.*;
+
+AuthyApiClient client = new AuthyApiClient("your-api-key")
 ```
 
-Create an API instance:
+![authy api key in console](https://s3.amazonaws.com/com.twilio.prod.twilio-docs/images/account-security-api-key.width-800.png)
 
-```java
-AuthyApiClient client = new AuthyApiClient("your-api-key", "https://api.authy.com/");
-```
+## 2FA Workflow
 
-or by default api url is `https://api.authy.com/`
+1. [Create a user](https://www.twilio.com/docs/authy/api/users#enabling-new-user)
+2. [Send a one-time password](https://www.twilio.com/docs/authy/api/one-time-passwords)
+3. [Verify a one-time password](https://www.twilio.com/docs/authy/api/one-time-passwords#verify-a-one-time-password)
 
-```java
-AuthyApiClient client = new AuthyApiClient("your-api-key");
-```
+**OR**
 
-or if you want to use in local mode or for debugging purpose
+1. [Create a user](https://www.twilio.com/docs/authy/api/users#enabling-new-user)
+2. [Send a push authentication](https://www.twilio.com/docs/authy/api/push-authentications)
+3. [Check a push authentication status](https://www.twilio.com/docs/authy/api/push-authentications#check-approval-request-status)
 
-```java
-AuthyApiClient client = new AuthyApiClient("your-api-key");
-String apiKey = "bf12974d70818a08199d17d5e2bae630";
-String apiUrl = "http://sandbox-api.authy.com";
-boolean debugMode = true;
 
-AuthyApiClient client = new AuthyApiClient(apiKey, apiUrl, debugMode);
-```
+## <a name="phone-verification"></a>Phone Verification
 
-Get a Users and Tokens instance:
-```java
-Users users = client.getUsers();
-Tokens tokens = client.getTokens();
-```
+[Phone verification now lives in the Twilio API](https://www.twilio.com/docs/verify/api) and has [Java support through the official Twilio helper libraries](https://www.twilio.com/docs/libraries/java). 
 
-## Registering a user
+[Legacy (V1) documentation here.](verify-legacy-v1.md) **Verify V1 is not recommended for new development. Please consider using [Verify V2](https://www.twilio.com/docs/verify/api)**.
 
-__NOTE: User is matched based on cellphone and country code not e-mail.
-A cellphone is uniquely associated with an authy_id.__
+## Copyright
 
-
-`users.createUser(String, String)` requires the user's e-mail address and cellphone. Optionally you can pass in the countryCode or we will assume USA. The call will return the authy id for the user that you need to store in your database.
-
-To create a user just use:
-```java
-User user = users.createUser("new_user@email.com", "405-342-5699", "57");
-// createUser takes as arguments the email, phone number and country code
-```
-
-You can check if the user was created calling `user.isOk()`.
-If the request was successful, you will need to store the authy id in your database. Use `user.getId()` to get this `id` in your database.
-
-```java
-
-  if(user.isOk()){
-    // Store user.getId() in your database
-  }
-```
-  If something goes wrong `user.isOk()` returns `false` and you can see the errors using the following code
-
-```java
-  user.getError();
-```
-
-  It returns an Error object explaining what went wrong with the request.
-
-## Verifying a user
-
-
-  __NOTE: Token verification is only enforced if the user has completed registration. To change this behaviour see Forcing Verification section below.__
-
-  >*Registration is completed once the user installs and registers the Authy mobile app or logins once successfully using SMS.*
-
-  `tokens.verify()` takes the authy_id that you are verifying and the token that you want to verify. You should have the authy_id in your database
-
-  Token verification = tokens.verify(authy_id, "token-user-entered");
-
-  Once again you can use `isOk()` to verify whether the token was valid or not.
-
-```java
-  if(verification.isOk()){
-  // token was valid, user can sign in
-  }else{
-    // token is invalid
-  }
-```
-  In case `verification.isOk()` returns `false`, you can get an Error object using `verification.getError()`
-
-### Forcing Verification
-
-  If you wish to verify tokens even if the user has not yet complete registration, pass force=true when verifying the token.
-```java
-  Map<String, String> options = new HashMap<String, String>();
-  options.put("force", "true");
-  Token verification = tokens.verify(authy_id, "token-user-entered", options);
-```
-
-## Deleting a user
-
-  `users.deleteUser()` takes the authy_id that you want to delete. You should have the authy_id in your database
-
-```java
-  Hash response = users.deleteUser();
-```
-
-  Once again you can use `isOk()` to verify whether the user was deleted or not.
-```java
-  if(response.isOk()){
-    // User was deleted
-  }else{
-    // Some error ocurred
-  }
-```
-
-  In case `response.isOk()` returns `false`, you can get an Error object using `response.getError()`
-
-## Requesting a Call token
-
-  `users.requestCall()` takes the authy_id that you want to send a call token.
-
-```java
-  Hash call = users.requestCall(authy_id);
-```
-
-  As always, you can use `isOk()` to verify if the token was sent.
-
-```java
-  if(call.isOk())
-  // call was started ;
-```
-
-  In case `call.isOk()` returns `false`, you can get an Error object using `call.getError()`
-
-  This call will be ignored if the user is using the Authy Mobile App.
-
-## Requesting a SMS token
-
-  `users.requestSms()` takes the authy_id that you want to send a SMS token. This requires Authy SMS plugin to be enabled.
-
-```java
-  Hash sms = users.requestSms(authy_id);
-```
-
-  As always, you can use `isOk()` to verify if the token was sent.
-
-```java
-  if(sms.isOk())
-  // sms was sent ;
-```
-
-  In case `sms.isOk()` returns `false`, you can get an Error object using `sms.getError()`
-
-  This call will be ignored if the user is using the Authy Mobile App. If you still want to send
-  the SMS pass force=true as an option
-
-```java
-  Map<String, String> options = new HashMap<String, String>();
-  options.put("force", "true");
-  Hash sms = users.requestSms(authy_id, options);
-```
-
-## OneTouch Support
-
-  `client.getOneTouch()` will return the OneTouch wrapper, with this component you will be able to use all the
-  endpoints defined in the [OneTouch API](https://www.twilio.com/docs/api/authy/authy-onetouch-api),
-  for example, using the
-  'sendApprovalRequest' method you will create an ApprovalRequest
-  in OneTouch, then the approval request
-  status can be queried by using the  `uuid` provided. (NOTE: The UUID is the unique identifier for the request sent to OneTouch). 'sendApprovalRequest' method need an intance of ApprovalRequestParams.class, you can create one using the ApprovalRequestParams.Builder like this:
-
-```java
- ApprovalRequestParams approvalRequestParams= new  ApprovalRequestParams.Builder(Integer.parseInt(103)),"Authorize OneTouch Unit Test")
-                .addDetail("username", "User")
-                .addDetail("location", "California,USA")
-                .addHiddenDetail("ip_address", "10.10.3.203")
-                .addLogo(Resolution.Default, "http://image.co")
-                .build();
-
-        OneTouchResponse response = client.getOneTouch().sendApprovalRequest(approvalRequestParams);
-    // If the request was successfuly created.
-    String uuid = response.getApprovalRequest().getUUID();
-    System.out.println(uuid);
-```
-
-  If you want to query the ApprovalRequest status
-```java
-  String status = client.getOneTouch().getApprovalRequestStatus(uuid).getStatus();
-  System.out.println(status);
-```
-When you make a OneTouch request, you will get a OneTouchResponse object which in turn will have a getApprovalRequest() accessor to retrieve the metadata from the given request, for example:
-
-```java
-    OneTouchResponse response = client.getOneTouch().getApprovalRequestStatus(uuid);
-    ApprovalRequest approvalRequest  = response.getApprovalRequest();
-    // was the user notified?
-    System.out.println("The user was "+(approvalRequest.isNotified()?"":"not")+" notified.");
-    // What is the status of the request?
-    System.out.print("The status of the request is: "+approvalRequest.getStatus());
-
-```
-As described in the documentation, you can define a callback from Authy to your web application were you will receive the result of your request with all the related information.
-
-After you define your callback, if you want to keep up with following our *Developer Best Practices* you should [Verify the authenticity of callbacks from Authy](https://www.twilio.com/docs/api/authy/authy-onetouch-api#verifying-authenticity-of-callbacks-from-authy) all this process can be done easily just by using an utility method from *AuthyUtil* like this:
-
-Inside your app your app will get a request into a servlet/controller were you will have the Http Request object.
-```java
-    // let's create a Map of Strings to put the query parameters from the Http Request
-    HashMap<String,String> params = new HashMap<>();
-    for(String p : request.queryParams()){
-        params.put(p,request.queryParams(p));
-    }
-
-    // let's create a Map of Strings to put the query headers from the Http Request
-    HashMap<String,String> headers = new HashMap<>();
-    for(String h : request.headers()){
-        headers.put(h,request.headers(h));
-    }
-
-    //Now it is really easy just to ask AuthyUtil to check the authenticity of the signature, TOKEN will be the string with your Api_key
-    // AuthyUtil.validateSignature will tell you if the request is secure or not!
-    boolean isValid = AuthyUtil.validateSignature(params, headers, request.requestMethod(), request.url(), TOKEN)
-
-     // Then you can just finish the rewquest with the proper HTTP code or do any other procesing you need for this case.
-     if(!isValid){
-         response.status(401);
-         return "Unauthorized";
-     }
-
-```
-
-
-## Phone Verification
-
-### Sending the verification code.
-
-  ```java
-  AuthyApiClient client = new AuthyApiClient("SomeApiKey");
-  PhoneVerification phoneVerification  = client.getPhoneVerification();
-
-  Verification verification;
-  Params params = new Params();
-  params.setAttribute("locale", en);
-
-  verification = phoneVerification.start("111-111-1111", "1", "sms", params);
-
-  System.out.println(verification.getMessage());
-  System.out.println(verification.getIsPorted());
-  System.out.println(verification.getSuccess());
-  System.out.println(verification.isOk());
-  ```
-
-### Check the verification code.
-  Once you sent the verification code the user will receive the code in the
-  mobile device. Then you need to provide this code to check if it is okay.
-
-
-  ```java
-  AuthyApiClient client = new AuthyApiClient("SomeApiKey");
-  PhoneVerification phoneVerification = client.getPhoneVerification();
-
-  Verification verification;
-  verification = phoneVerification.check("111-111-1111", "1", "2061");
-
-  System.out.println(verificationCode.getMessage());
-  System.out.println(verificationCode.getIsPorted());
-  System.out.println(verificationCode.getSuccess());
-  ```
-
-## Phone Intelligence
-  Getting more info about a phone number.
-
-  ```java
-  AuthyApiClient client = new AuthyApiClient("SomeApiKey");
-  PhoneInfo phoneInfo  = client.getPhoneInfo();
-  PhoneInfoResponse phoneInfoResponse;
-
-  phoneInfoResponse = phoneInfo.info("111-111-1111", "1");
-
-  System.out.println(phoneInfoResponse.getMessage());
-  System.out.println(phoneInfoResponse.getProvider());
-  System.out.println(phoneInfoResponse.getSuccess());
-  System.out.println(phoneInfoResponse.getIsPorted());
-  System.out.println(phoneInfoResponse.getType());
-  ```
-
-  Copyright
-  ==
-
-  Copyright (c) 2011-2020 Authy Inc. See LICENSE.txt for
-  further details.
+Copyright (c) 2011-2020 Authy Inc. See [LICENSE](https://github.com/twilio/authy-java/blob/master/LICENSE.txt) for further details.

--- a/verify-legacy-v1.md
+++ b/verify-legacy-v1.md
@@ -1,0 +1,48 @@
+# Phone Verification V1
+
+[Version 2 of the Verify API is now available!](https://www.twilio.com/docs/verify/api) V2 has an improved developer experience and new features. Some of the features of the V2 API include:
+
+* Twilio helper libraries in JavaScript, Java, C#, Python, Ruby, and PHP
+* PSD2 Secure Customer Authentication Support
+* Improved Visibility and Insights
+
+**You are currently viewing Version 1. V1 of the API will be maintained for the time being, but any new features and development will be on Version 2. We strongly encourage you to do any new development with API V2.** Check out the [migration guide](https://www.twilio.com/docs/verify/api/migrating-1x-2x) or the API Reference for more information.
+
+### API Reference
+
+API Reference is available at https://www.twilio.com/docs/verify/api/v1
+
+### Sending the verification code.
+
+  ```java
+  AuthyApiClient client = new AuthyApiClient("SomeApiKey");
+  PhoneVerification phoneVerification  = client.getPhoneVerification();
+
+  Verification verification;
+  Params params = new Params();
+  params.setAttribute("locale", en);
+
+  verification = phoneVerification.start("111-111-1111", "1", "sms", params);
+
+  System.out.println(verification.getMessage());
+  System.out.println(verification.getIsPorted());
+  System.out.println(verification.getSuccess());
+  System.out.println(verification.isOk());
+  ```
+
+### Check the verification code.
+  Once you sent the verification code the user will receive the code in the
+  mobile device. Then you need to provide this code to check if it is okay.
+
+
+  ```java
+  AuthyApiClient client = new AuthyApiClient("SomeApiKey");
+  PhoneVerification phoneVerification = client.getPhoneVerification();
+
+  Verification verification;
+  verification = phoneVerification.check("111-111-1111", "1", "2061");
+
+  System.out.println(verificationCode.getMessage());
+  System.out.println(verificationCode.getIsPorted());
+  System.out.println(verificationCode.getSuccess());
+  ```


### PR DESCRIPTION
Updates the README to be consistent with other Twilio supported helper libraries for Authy.

See:
https://www.twilio.com/docs/authy/api/applications
https://www.twilio.com/docs/authy/api/users
https://www.twilio.com/docs/authy/api/one-time-passwords
https://www.twilio.com/docs/authy/api/push-authentications

Also moves Verify V1 docs to a legacy readme and guides folks towards V2 of Verify

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
