### PR TITLE
Removed failing JDK from travis ci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: java
 jdk:
-  - oraclejdk8
   - openjdk8
 
 script: "mvn cobertura:cobertura"


### PR DESCRIPTION
Removed failing JDK from travis ci config

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
